### PR TITLE
Fixed error in FDR-peaks and track-hub

### DIFF
--- a/workflow/rules/FDR-peaks.smk
+++ b/workflow/rules/FDR-peaks.smk
@@ -269,7 +269,7 @@ rule wide_fdr_peaks:
         echo $TMP
         ( \
             zcat {input.bed}; \
-            bioawk -tc hdr '$FDR<={params.max_peak_fdr}' {input.track} \
+            bioawk -tc hdr 'NR==1 || $FDR<={params.max_peak_fdr}' {input.track} \
                 | bioawk -tc hdr 'NR==1 || ($fire_coverage/$coverage>{params.min_per_acc_peak})' \
         ) \
             | cut -f 1-3 \

--- a/workflow/rules/track-hub.smk
+++ b/workflow/rules/track-hub.smk
@@ -19,7 +19,7 @@ rule percent_accessible:
         zcat {input.bed} \
             | hck -f 1-3 {params.cols} \
             | grep -v "^#" \
-            | awk -v OFS='\t' '$5 > 0 {{print $1,$2,$3,$4/$5}}' \
+            | awk -v OFS='\t' '$5 > 0 {{print $1,$2,$3,$4*100/$5}}' \
         > {output.tmp}
 
         # skip if the file is empty


### PR DESCRIPTION
In FDR-peaks.smk, fixed bug in rule wide_fdr_peaks

In track-hub.smk, multiplied by 100 within rule percent-accessible so that track displays percent and not fraction.